### PR TITLE
upgrade docker cli version to v27.1.2

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ env:
   IMAGE_NAME: ghcr.io/quiknode-labs/docker-ansible-core
   LATEST_OS: alpine
   LATEST_VERSION: v2.16
-  DOCKER_CLI_VERSION: "20.10.14"
+  DOCKER_CLI_VERSION: "27.1.2"
   GOSU_VERSION: "1.14"
 
 jobs:


### PR DESCRIPTION
Upgrading docker cli version to the latest version of https://docs.docker.com/engine/release-notes/27.1/#2712