### PR TITLE
feat: TEC-1556/remove 2.18 for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,3 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-minor", "version-update:semver-major"]
-  - package-ecosystem: pip
-    directory: "/requirements/v2.18"
-    schedule:
-      interval: daily
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-minor", "version-update:semver-major"]

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -10,7 +10,7 @@ on:
 env:
   IMAGE_NAME: ghcr.io/quiknode-labs/docker-ansible-core
   LATEST_OS: ubuntu
-  LATEST_VERSION: v2.18
+  LATEST_VERSION: v2.17
   DOCKER_CLI_VERSION: "27.1.2"
   GOSU_VERSION: "1.17"
 jobs:
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu]
-        version: [v2.16, v2.17, v2.18]
+        version: [v2.16, v2.17]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ If you find bugs or got improvements of the container, feel free to submit it [h
 
 ## Simple Tags
 
-- `v2.18-ubuntu`
+- `v2.17-ubuntu`
 
 ## Shared Tags
 
-- `v2.18`, `latest-ubuntu`, `latest`
+- `v2.17`, `latest-ubuntu`, `latest`
 
 ## Additions
 

--- a/requirements/v2.18/requirements.txt
+++ b/requirements/v2.18/requirements.txt
@@ -1,2 +1,0 @@
-ansible-core==2.18.3
-mitogen==0.3.22


### PR DESCRIPTION
2.18 is not available in Ubuntu pip3 repo.

![image](https://github.com/user-attachments/assets/28b78098-2769-46cc-a994-98a09d790c03)

So, sticking with 2.17 for now.