### PR TITLE
feat: TEC-1680/add-native-mitogen-integration

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,20 +1,16 @@
 name: docker-image
 on:
-  push:
+  pull_request:
     branches:
       - main
-    tags:
-      - '*.*.*'
-  schedule:
-    - cron: '0 1 * * 0'
+  release:
+    types: [published]
 env:
   IMAGE_NAME: ghcr.io/quiknode-labs/docker-ansible-core
   LATEST_OS: ubuntu
   LATEST_VERSION: v2.17
-  DOCKER_CLI_VERSION: "27.1.2"
-  GOSU_VERSION: "1.17"
 jobs:
-  build_push_python38_and_later:
+  build_and_push_on_release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -30,32 +26,38 @@ jobs:
       - name: Prepare
         id: prep
         run: |
+          # Copy the appropriate requirements file
           cp requirements/${MATRIX_VERSION}/requirements.txt requirements/requirements.txt
-          TAGS="${IMAGE_NAME}:${MATRIX_VERSION}-${MATRIX_OS}"
+
+          # Extract the full ansible-core version (e.g. "2.16.14")
+          ANSIBLE_CORE_VERSION=$(grep ansible-core requirements/${MATRIX_VERSION}/requirements.txt | cut -d "=" -f 3)
+
+          # Create both the patch version tag and the legacy matrix version tag
+          TAGS="${IMAGE_NAME}:${ANSIBLE_CORE_VERSION}-${MATRIX_OS},${IMAGE_NAME}:${MATRIX_VERSION}-${MATRIX_OS}"
+          # If running on the latest OS, add additional tags.
           if [[ "$MATRIX_OS" == "$LATEST_OS" ]]; then
-            TAGS="${TAGS},${IMAGE_NAME}:$MATRIX_VERSION"
+            TAGS="${TAGS},${IMAGE_NAME}:${ANSIBLE_CORE_VERSION}"
+            # Also handle 'latest' if this is the latest version you expect
             if [[ "$MATRIX_VERSION" == "$LATEST_VERSION" ]]; then
               TAGS="${TAGS},${IMAGE_NAME}:latest-${MATRIX_OS},${IMAGE_NAME}:latest"
             fi
           elif [[ "$MATRIX_VERSION" == "$LATEST_VERSION" ]]; then
             TAGS="${TAGS},${IMAGE_NAME}:latest-${MATRIX_OS}"
           fi
+
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
           echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
         env:
           MATRIX_OS: ${{ matrix.os }}
           MATRIX_VERSION: ${{ matrix.version }}
 
-      - name: Set up QEMU
+      - name: Set up QEMU to support cross-architecture builds
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
 
-      - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
-
-      - name: Build and Push
+      - name: Build Image and push to ghcr only on Release
         uses: docker/build-push-action@v6
         with:
           platforms: linux/amd64,linux/arm64
@@ -65,10 +67,19 @@ jobs:
             org.opencontainers.image.version=${{ matrix.version }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.licenses=${{ github.event.repository.license.name }}
-          build-args: |
-            docker_version=${{ env.DOCKER_CLI_VERSION }}
-            gosu_version=${{ env.GOSU_VERSION }}
           context: .
           file: ./Dockerfile.${{ matrix.os }}
           tags: ${{ steps.prep.outputs.tags }}
-          push: true
+          # Push only on release events; for PRs, just build.
+          push: ${{ github.event_name == 'release' }}
+          secrets: |
+            GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
+
+      # Test Run: Only run test on PR events (you might choose to run tests on release as well)
+      - name: Test Run
+        if: github.event_name == 'pull_request'
+        run: |
+          # Extract the first tag from the output tags
+          TAG=$(echo "${{ steps.prep.outputs.tags }}" | cut -d',' -f1)
+          echo "Testing image with tag: $TAG"
+          docker run --rm $TAG

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,16 +72,5 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
           # Push only on release events; for PRs, just build.
           push: ${{ github.event_name == 'release' }}
-          # Load the image into the local Docker daemon for PR events
-          load: ${{ github.event_name != 'release' }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
-
-      # Test Run: Only run test on PR events (you might choose to run tests on release as well)
-      - name: Test Run
-        if: github.event_name == 'pull_request'
-        run: |
-          # Extract the first tag from the output tags
-          TAG=$(echo "${{ steps.prep.outputs.tags }}" | cut -d',' -f1)
-          echo "Testing image with tag: $TAG"
-          docker run --rm $TAG

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,6 +72,8 @@ jobs:
           tags: ${{ steps.prep.outputs.tags }}
           # Push only on release events; for PRs, just build.
           push: ${{ github.event_name == 'release' }}
+          # Load the image into the local Docker daemon for PR events
+          load: ${{ github.event_name != 'release' }}
           secrets: |
             GIT_AUTH_TOKEN=${{ secrets.GITHUB_TOKEN }}
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+requirements/requirements.txt

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,80 +1,74 @@
 FROM ubuntu:22.04
 
-LABEL org.opencontainers.image.title="haxorof/ansible-core" \
-      org.opencontainers.image.description="Ansible Core + additions" \
-      org.opencontainers.image.licenses="MIT"
-
-ARG docker_version
-ARG gosu_version
-
-ENV DEBIAN_FRONTEND=noninteractive
-ENV DEFAULT_LOCAL_TMP=/var/tmp/.ansible/tmp
+LABEL org.opencontainers.image.title="quiknode-labs/docker-ansible-core" \
+      org.opencontainers.image.description="Ansible Core + additions"
+ENV DEBIAN_FRONTEND=noninteractive \
+    DEFAULT_LOCAL_TMP=/var/tmp/.ansible/tmp
 
 ONBUILD USER root
 
 COPY requirements/requirements.txt ./requirements.txt
+COPY entrypoint.sh /entrypoint.sh
 
-RUN \
-    apt update \
-    && apt -y install \
+# Install prerequisites, add 1Password repo and install 1password-cli
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install \
        curl \
        gnupg \
-    # Instructions for installing 1password cli: https://support.1password.com/install-linux/#get-1password-for-linux
-    && curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg \
-    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list \
-    && mkdir -p /etc/debsig/policies/AC2D62742012EA22/ \
-    && curl -sS https://downloads.1password.com/linux/debian/debsig/1password.pol | tee /etc/debsig/policies/AC2D62742012EA22/1password.policies \
-    && apt-get -y clean \
-    && apt-get -y update \
-    && apt-get -y install apt-utils \
-    && apt-get -y upgrade \
-    && apt-get -y install \
-    && apt-get -y install ruby-full \
-    sshpass \
-    git \
-    sudo \
-    python3-pip \
-    wget \
-    curl \
-    tzdata \
-    cargo \
-    rsync \
-    1password-cli \
-    # install gosu for a better su+exec command based on architecture
-    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-         wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-amd64"; \
-       elif [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-         wget -O /usr/bin/gosu "https://github.com/tianon/gosu/releases/download/$gosu_version/gosu-arm64"; \
-       else \
-         echo "Unsupported architecture: $(dpkg --print-architecture)"; exit 1; \
-       fi \
-    && chmod +x /usr/bin/gosu \
-    && gosu nobody true \
-    && python3 -m pip install --no-cache-dir --upgrade pip \
-    && python3 -m pip install --no-cache-dir -r requirements.txt \
-    # download Docker CLI for the appropriate architecture
-    && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
-         wget -O - https://download.docker.com/linux/static/stable/x86_64/docker-${docker_version}.tgz | tar -xz -C /usr/lib; \
-       elif [ "$(dpkg --print-architecture)" = "arm64" ]; then \
-         wget -O - https://download.docker.com/linux/static/stable/aarch64/docker-${docker_version}.tgz | tar -xz -C /usr/lib; \
-       else \
-         echo "Unsupported architecture: $(dpkg --print-architecture)"; exit 1; \
-       fi \
-    && ln -s /usr/lib/docker/docker /usr/bin/docker \
-    && mkdir -p /etc/ansible/roles \
-    && echo 'localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3' > /etc/ansible/hosts \
-    && apt-get clean \
-    && useradd -m -u 1000 ansible-1000 \
-    && useradd -m -u 1001 ansible-1001 \
-    && useradd -m -u 10000 ansible-10000 \
-    && echo 'ansible-1000   ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible \
-    && echo 'ansible-1001   ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible \
-    && echo 'ansible-10000  ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible
+       apt-utils \
+       ruby-full \
+       sshpass \
+       git \
+       sudo \
+       python3-pip \
+       wget \
+       tzdata \
+       cargo \
+       rsync \
+       gosu
 
+# 1Password CLI installation steps
+RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \
+    mkdir -p /etc/debsig/policies/AC2D62742012EA22/ && \
+    curl -sS https://downloads.1password.com/linux/debsig/1password.pol | tee /etc/debsig/policies/AC2D62742012EA22/1password.policies && \
+    apt-get update && \
+    apt-get -y install 1password-cli
+
+# Upgrade pip and install Python requirements
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    python3 -m pip install --no-cache-dir -r requirements.txt
+
+# Set up Ansible environment and create users with sudo privileges
+RUN mkdir -p /etc/ansible/roles && \
+    echo 'localhost ansible_connection=local ansible_python_interpreter=/usr/bin/python3' > /etc/ansible/hosts && \
+    useradd -m -u 1000 ansible-1000 && \
+    useradd -m -u 1001 ansible-1001 && \
+    useradd -m -u 10000 ansible-10000 && \
+    echo 'ansible-1000   ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible && \
+    echo 'ansible-1001   ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible && \
+    echo 'ansible-10000  ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible
+
+# Install bundler via gem
 RUN gem install bundler
-RUN pip3 install jmespath
+
+RUN PYTHON_SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])') && \
+    echo "export ANSIBLE_STRATEGY_PLUGINS=${PYTHON_SITE_PACKAGES}/ansible_mitogen" > /etc/profile.d/ansible-global-settings.sh
+
+# Cleanup and other things
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/* && \
+    rm -rf /root/.ansible && \
+    rm -rf /root/.cache && \
+    chmod +x /entrypoint.sh
+
 WORKDIR /mnt
 
 USER ansible-10000
 
-CMD [ "ansible-playbook", "playbook.yml" ]
+# Use the entrypoint script and default command
+ENTRYPOINT ["/entrypoint.sh"]
+CMD [ "ansible", "--version" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,33 +11,40 @@ ONBUILD USER root
 COPY requirements/requirements.txt ./requirements.txt
 COPY entrypoint.sh /entrypoint.sh
 
-# Install prerequisites, add 1Password repo and install 1password-cli
+# Install prerequisites, add 1Password repo, install 1password-cli, cleanup apt junk
 RUN apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install \
-       curl \
-       gnupg \
-       apt-utils \
-       ruby-full \
-       sshpass \
-       git \
-       sudo \
-       python3-pip \
-       wget \
-       tzdata \
-       cargo \
-       rsync
-
-# 1Password CLI installation steps
-RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
+    apt-get -y --no-install-recommends install \
+      curl \
+      gnupg \
+      apt-utils \
+      ruby-full \
+      sshpass \
+      git \
+      sudo \
+      python3-pip \
+      wget \
+      tzdata \
+      cargo \
+      rsync && \
+    curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \
     mkdir -p /etc/debsig/policies/AC2D62742012EA22/ && \
     curl -sS https://downloads.1password.com/linux/debsig/1password.pol | tee /etc/debsig/policies/AC2D62742012EA22/1password.policies && \
     apt-get update && \
-    apt-get -y install 1password-cli
+    apt-get -y --no-install-recommends install 1password-cli && \
+    apt-get autoremove -y && \
+    apt-get autoclean -y && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    rm -rf /tmp/* && \
+    rm -rf /var/tmp/* && \
+    rm -rf /root/.ansible && \
+    rm -rf /root/.cache
 
-# Upgrade pip and install Python requirements
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+# Install defferent dependencies
+RUN gem install bundler && \
+    python3 -m pip install --no-cache-dir --upgrade pip && \
     python3 -m pip install --no-cache-dir -r requirements.txt
 
 # Set up Ansible environment and create users with sudo privileges
@@ -48,21 +55,9 @@ RUN mkdir -p /etc/ansible/roles && \
     useradd -m -u 10000 ansible-10000 && \
     echo 'ansible-1000   ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible && \
     echo 'ansible-1001   ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible && \
-    echo 'ansible-10000  ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible
-
-# Install bundler via gem
-RUN gem install bundler
-
-RUN PYTHON_SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])') && \
-    echo "export ANSIBLE_STRATEGY_PLUGINS=${PYTHON_SITE_PACKAGES}/ansible_mitogen" > /etc/profile.d/ansible-global-settings.sh
-
-# Cleanup and other things
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    rm -rf /tmp/* && \
-    rm -rf /var/tmp/* && \
-    rm -rf /root/.ansible && \
-    rm -rf /root/.cache && \
+    echo 'ansible-10000  ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible && \
+    PYTHON_SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])') && \
+    echo "export ANSIBLE_STRATEGY_PLUGINS=${PYTHON_SITE_PACKAGES}/ansible_mitogen" > /etc/profile.d/ansible-global-settings.sh && \
     chmod +x /entrypoint.sh
 
 WORKDIR /mnt

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,6 +2,7 @@ FROM ubuntu:22.04
 
 LABEL org.opencontainers.image.title="quiknode-labs/docker-ansible-core" \
       org.opencontainers.image.description="Ansible Core + additions"
+
 ENV DEBIAN_FRONTEND=noninteractive \
     DEFAULT_LOCAL_TMP=/var/tmp/.ansible/tmp
 
@@ -25,8 +26,7 @@ RUN apt-get update && \
        wget \
        tzdata \
        cargo \
-       rsync \
-       gosu
+       rsync
 
 # 1Password CLI installation steps
 RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,9 +11,14 @@ ONBUILD USER root
 COPY requirements/requirements.txt ./requirements.txt
 COPY entrypoint.sh /entrypoint.sh
 
-# Install prerequisites, add 1Password repo, install 1password-cli, cleanup apt junk
+# Upgrade system packages in one dedicated layer (run less frequently)
 RUN apt-get update && \
     apt-get -y upgrade && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install prerequisites, add 1Password repo, install 1password-cli, cleanup apt junk
+RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       curl \
       gnupg \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Ansible Core + additions
 
-[![Docker Pulls](https://img.shields.io/docker/pulls/haxorof/ansible-core)](https://hub.docker.com/r/haxorof/ansible-core/)
-[![License](https://img.shields.io/github/license/haxorof/docker-ansible-core)](https://hub.docker.com/r/haxorof/ansible-core/)
-[![CI](https://github.com/haxorof/docker-ansible-core/workflows/CI/badge.svg)](https://github.com/haxorof/docker-ansible-core/actions?query=workflow%3ACI)
-
 Ansible Core with additions.
 
 **Note!** This image is called `ansible-core` but installs `ansible-base` for v2.10 (EOL). For later versions, v2.11 and onwards the `ansible-core` package is installed.
@@ -38,7 +34,6 @@ Container will run as user `ansible-10000` by default. However, when you build y
 
 ### Packages/Tools
 
-- docker-cli
 - git
 - openssh
 - sudo
@@ -53,28 +48,8 @@ USERNAME=Myname
 echo $GITHUB_TOKEN | docker login ghcr.io -u $USERNAME --password-stdin
 ```
 
-Below assume a `playbook.yml` file is located in current directory:
-
-```sh
-docker run --rm -v ${PWD}:/mnt ghcr.io/quiknode-labs/docker-ansible-core:v2.16-ubuntu
-```
-
 To override the default command set you can just add your own arguments after the images name:
 
 ```sh
 docker run --rm -v ${PWD}:/mnt ghcr.io/quiknode-labs/docker-ansible-core:v2.16-ubuntu ansible -m setup -c local localhost
-```
-
-## How to use Docker CLI with Ansible to target Python container
-
-Start a Python container in a terminal:
-
-```sh
-docker run -it --rm --name=target python sh
-```
-
-In a second terminal run the following which will do an Ansible ping to that Python container:
-
-```sh
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/quiknode-labs/docker-ansible-core:v2.16-ubuntu sh -c "echo 'target ansible_connection=docker' > hosts && ansible -m ping -i hosts all"
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -e
+
+source /etc/profile.d/ansible-global-settings.sh
+
+# Execute the command passed as arguments to the container
+exec "$@"

--- a/requirements/v2.16/requirements.txt
+++ b/requirements/v2.16/requirements.txt
@@ -1,2 +1,3 @@
 ansible-core==2.16.14
 mitogen==0.3.22
+jmespath==1.0.1

--- a/requirements/v2.17/requirements.txt
+++ b/requirements/v2.17/requirements.txt
@@ -1,2 +1,3 @@
-ansible-core==2.17.9
+ansible-core==2.17.10
 mitogen==0.3.22
+jmespath==1.0.1


### PR DESCRIPTION
## Overview

This PR overhauls our Docker image build process and associated GitHub Actions workflows. The changes are aimed at streamlining our CI/CD pipeline, reducing image size, and improving build efficiency while ensuring that image releases and tests are clearly separated.

## Key Changes

- **Workflow Triggers & Image Pushing**  
  - Docker images are now **pushed to the GHCR registry only during repository Releases**.
  - For pull requests, images are built and tested locally without pushing, eliminating unnecessary registry interactions.
  - Removed the cron schedule since repository changes are now only made via PRs.

- **Dockerfile Optimizations**  
  - **Removed Docker CLI installation:** The Docker CLI is no longer installed in the image since it's not used from within the container.
  - **Removed gosu installation:** As we don't utilize gosu anywhere in our codebase, this dependency has been eliminated ([code search reference](https://github.com/search?q=org%3Aquiknode-labs+gosu&type=code&p=2)).
  - **Release Tag Alignment:** Docker image release tags now support the Ansible patch version, aligned with the `ansible-core` version.
  - **Authentication Simplification:** The `Log into registry` step has been removed from the workflow because the `docker/build-push-action` now natively supports authentication via `GITHUB_TOKEN`.
  - **Eliminated duplicate LABELs:** Redundant Dockerfile `LABEL` entries have been removed.
  - **Reorganized and Optimized Dockerfile:**  
    - An **entrypoint script** has been added to support exporting dynamic environment variables.
    - Consolidated all apt installations into a single `RUN` command for efficiency.
    - Updated the default `CMD` to run only `ansible --version` to avoid unintended playbook executions.
    - Consolidated all Python dependencies into a single `requirements.txt` file, removing the need for separate `RUN` commands.
    - Introduced a dynamic `ANSIBLE_STRATEGY_PLUGINS` configuration that detects and points to the location of mitogen strategies. This can be verified by running `ansible-doc -t strategy -l`. Now, placing any mitogen strategies in your `ansible.cfg` is sufficient—no extra configuration is required.

- **Image Improvements**  
  - **Ansible-core versions upgraded.**
  - **Reduced Image Size:** The unarchived image size has decreased from 1.2GB to nearly 900MB.

## TODO

- Research what components or dependencies from the existing `.drone.yml` can be integrated into the default installation to further streamline the image.
