### PR TITLE
fix: TEC-1680/more-fixes

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,10 +3,16 @@ on:
   pull_request:
     branches:
       - main
+  # this will work for manual release
   release:
     types:
-      - created
       - published
+  # this will work for auto release
+  # triggered by release-please action
+  workflow_run:
+    workflows: ["release-please"]
+    types:
+      - completed
 env:
   IMAGE_NAME: ghcr.io/quiknode-labs/docker-ansible-core
   LATEST_OS: ubuntu

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -31,7 +31,9 @@ RUN apt-get update && \
       wget \
       tzdata \
       cargo \
-      rsync && \
+      rsync \
+      openssh-client \
+      && \
     curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \
     mkdir -p /etc/debsig/policies/AC2D62742012EA22/ && \


### PR DESCRIPTION
openssh-client is needed for `ssh-keyscan` and `ssh-agent` and etc tools:
https://github.com/quiknode-labs/role_solana/blob/0b1b1852c3dfedfc6ff3428a6b4cf68ff0534c1b/.drone.yml#L24