### PR TITLE
fix: TEC-1680/more-fixes2

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        if: ${{ github.event_name == 'release' }}
+        # if: ${{ github.event_name == 'release' || github.event_name == 'workflow_run' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -87,4 +87,4 @@ jobs:
           file: ./Dockerfile.${{ matrix.os }}
           tags: ${{ steps.prep.outputs.tags }}
           # Push only on release events; for PRs, just build.
-          push: ${{ github.event_name == 'release' }}
+          push: true

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
-        # if: ${{ github.event_name == 'release' || github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'release' || github.event_name == 'workflow_run' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -87,4 +87,4 @@ jobs:
           file: ./Dockerfile.${{ matrix.os }}
           tags: ${{ steps.prep.outputs.tags }}
           # Push only on release events; for PRs, just build.
-          push: true
+          push: ${{ github.event_name == 'release' || github.event_name == 'workflow_run' }}

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -34,6 +34,10 @@ RUN apt-get update && \
       rsync \
       openssh-client \
       less \
+      gcc-multilib \
+      libc-devtools \
+      make \
+      patch \
       && \
     curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \
@@ -48,7 +52,9 @@ RUN apt-get update && \
     rm -rf /tmp/* && \
     rm -rf /var/tmp/* && \
     rm -rf /root/.ansible && \
-    rm -rf /root/.cache
+    rm -rf /root/.cache && \
+    apt-get update
+# The latest apt-get update is needed to ensure that the apt cache is up to date for the backward compatibility
 
 # Install defferent dependencies
 RUN gem install bundler && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -33,6 +33,7 @@ RUN apt-get update && \
       cargo \
       rsync \
       openssh-client \
+      less \
       && \
     curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -3,8 +3,10 @@ FROM ubuntu:22.04
 LABEL org.opencontainers.image.title="quiknode-labs/docker-ansible-core" \
       org.opencontainers.image.description="Ansible Core + additions"
 
+# ANSIBLE_STRATEGY_PLUGINS is Hardcoded, because it's impossible to set dinamically
 ENV DEBIAN_FRONTEND=noninteractive \
-    DEFAULT_LOCAL_TMP=/var/tmp/.ansible/tmp
+    DEFAULT_LOCAL_TMP=/var/tmp/.ansible/tmp \
+    ANSIBLE_STRATEGY_PLUGINS=/usr/local/lib/python3.10/dist-packages/ansible_mitogen
 
 ONBUILD USER root
 
@@ -68,14 +70,17 @@ RUN mkdir -p /etc/ansible/roles && \
     echo 'ansible-1000   ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/ansible && \
     echo 'ansible-1001   ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible && \
     echo 'ansible-10000  ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers.d/ansible && \
-    PYTHON_SITE_PACKAGES=$(python3 -c 'import site; print(site.getsitepackages()[0])') && \
-    echo "export ANSIBLE_STRATEGY_PLUGINS=${PYTHON_SITE_PACKAGES}/ansible_mitogen" > /etc/profile.d/ansible-global-settings.sh && \
-    chmod +x /entrypoint.sh
+    EXPECTED_PATH=$(python3 -c 'import site; print(site.getsitepackages()[0])') && \
+    if [ "$ANSIBLE_STRATEGY_PLUGINS" != "${EXPECTED_PATH}/ansible_mitogen" ]; then \
+      echo "Error: ANSIBLE_STRATEGY_PLUGINS is set to '$ANSIBLE_STRATEGY_PLUGINS' but expected '${EXPECTED_PATH}/ansible_mitogen'. Please, update Dockerfile.ubuntu."; \
+      exit 1; \
+    else \
+      echo "ANSIBLE_STRATEGY_PLUGINS is correctly set to '$ANSIBLE_STRATEGY_PLUGINS'"; \
+    fi
 
 WORKDIR /mnt
 
 USER ansible-10000
 
 # Use the entrypoint script and default command
-ENTRYPOINT ["/entrypoint.sh"]
 CMD [ "ansible", "--version" ]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -54,7 +54,8 @@ RUN apt-get update && \
     rm -rf /root/.ansible && \
     rm -rf /root/.cache && \
     apt-get update
-# The latest apt-get update is needed to ensure that the apt cache is up to date for the backward compatibility
+# The latest apt-get update command is needed to ensure that the apt cache is up to date for the backward compatibility
+# Some DroneCI pupelines run apt-get install without apt-get update before
 
 # Install defferent dependencies
 RUN gem install bundler && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -34,8 +34,6 @@ RUN apt-get update && \
       rsync \
       openssh-client \
       less \
-      gcc-multilib \
-      libc-devtools \
       make \
       patch \
       && \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,7 +11,6 @@ ENV DEBIAN_FRONTEND=noninteractive \
 ONBUILD USER root
 
 COPY requirements/requirements.txt ./requirements.txt
-COPY entrypoint.sh /entrypoint.sh
 
 # Upgrade system packages in one dedicated layer (run less frequently)
 RUN apt-get update && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -e
-
-source /etc/profile.d/ansible-global-settings.sh
-
-# Execute the command passed as arguments to the container
-exec "$@"


### PR DESCRIPTION
This PR 
1. removes `entrypoint.sh`. 
Drone CI overrides `entrypoint.sh` if the pipeline has `commands:` defined. 
(c) https://docs.drone.io/pipeline/docker/syntax/steps/
which says
> The commands are executed inside the root directory of your git repository. The root of your git repository, also called the workspace, is shared by all steps in your pipeline. This allows file artifacts to persist between steps. **NB “commands” overrides the docker entrypoint.**

2. modifies `ANSIBLE_STRATEGY_PLUGINS` 
Because we cannot use entrypoint with Drone, the only way to define `ANSIBLE_STRATEGY_PLUGINS`  is to hardcode the path into Dockerfile and also, I have added an `if` statement, that will verify if path changed or not during the build process. 

3. Adds final `apt-get update`
We need `apt-get update` for backward compatibility with Drone CI tasks that run `apt-get install X` without `apt-get update`.