### PR TITLE
fix: TEC-2210 - install more popular deps and upgrade ansible

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -45,6 +45,8 @@ RUN apt-get update && \
       libclang-dev \
       llvm-dev \
       ca-certificates \
+      python3-netaddr \
+      jq \
       && \
     curl -sS https://downloads.1password.com/linux/keys/1password.asc | gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | tee /etc/apt/sources.list.d/1password.list && \

--- a/requirements/v2.17/requirements.txt
+++ b/requirements/v2.17/requirements.txt
@@ -1,3 +1,3 @@
-ansible-core==2.17.10
+ansible-core==2.17.12
 mitogen==0.3.24
 jmespath==1.0.1


### PR DESCRIPTION
Those packeages are pretty popular and used in almost every role:
- jq - https://github.com/search?q=org%3Aquiknode-labs+jq+language%3Ayaml&type=code
- python3-netaddr - https://github.com/search?q=org%3Aquiknode-labs%20python3-netaddr&type=code

Ansible 2.17 has new patches:

> [v2.17.12](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id33)
[Release Summary](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id34)
Release Date: 2025-05-19
[Porting Guide](https://docs.ansible.com/ansible-core/2.17/porting_guides/porting_guide_core_2.17.html)
[Minor Changes](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id35)
ansible-test - Replace FreeBSD 14.0 remote with FreeBSD 14.1.
ansible-test - Use the -t option to set the stop timeout when stopping a container. This avoids use of the --time option which was deprecated in Docker v28.0.
[Bugfixes](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id36)
Ansible will now ensure predictable permissions on remote artifacts, until now it only ensured executable and relied on system masks for the rest.
ansible-doc - fix indentation for first line of descriptions of suboptions and sub-return values (https://github.com/ansible/ansible/pull/84690).
ansible-doc - fix line wrapping for first line of description of options and return values (https://github.com/ansible/ansible/pull/84690).
script - Fix up become support for Windows scripts when become was set through host variables and not on the task directly - https://github.com/ansible/ansible/issues/85076
[v2.17.11](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id37)
[Release Summary](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id38)
Release Date: 2025-04-21
[Porting Guide](https://docs.ansible.com/ansible-core/2.17/porting_guides/porting_guide_core_2.17.html)
[Bugfixes](https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst#id39)
build - Pin wheel in pyproject.toml to ensure compatibility with supported setuptools versions.
gather_facts action, will now add setup when 'smart' appears with other modules in the FACTS_MODULES setting (#84750).

https://github.com/ansible/ansible/blob/v2.17.12/changelogs/CHANGELOG-v2.17.rst