### PR TITLE
Revert "fix: Sjoshi10 patch add netaddr"

### DIFF
--- a/requirements/v2.16/requirements.txt
+++ b/requirements/v2.16/requirements.txt
@@ -1,4 +1,3 @@
 ansible-core==2.16.14
 mitogen==0.3.24
 jmespath==1.0.1
-netaddr==1.3.0

--- a/requirements/v2.17/requirements.txt
+++ b/requirements/v2.17/requirements.txt
@@ -1,4 +1,3 @@
 ansible-core==2.17.12
 mitogen==0.3.24
 jmespath==1.0.1
-netaddr==1.3.0


### PR DESCRIPTION
Reverts quiknode-labs/docker-ansible-core#55

I think we already installed netaddr by apt here:
https://github.com/quiknode-labs/docker-ansible-core/blob/main/Dockerfile.ubuntu#L48
I added netaddr very recently (~3 weeks ago).
https://github.com/quiknode-labs/docker-ansible-core/pull/52

So, having `netaddr` in pip dependencies and apt might cause conflicts and even break some roles because 2.17 Ansible is not compatible with anything above netaddr 1.0.